### PR TITLE
Style adjustment

### DIFF
--- a/src/components/BlockTitleDescription/index.js
+++ b/src/components/BlockTitleDescription/index.js
@@ -17,7 +17,7 @@ class BlockTitleDescription extends PureComponent {
           <div className="col-12 lg:col-4 w100">
             {!!title ? <h2 className="block-title bold mt_5 mb1">{title}</h2> : null}
           </div>
-          <div className="col-12 lg:col-8 w100 lg:pl1">
+          <div className="col-12 lg:col-8 w100 lg:pl1 lg:mt1">
             {documentToReactComponents(richText, richTextOptions('blockTitleDescription'))}
           </div>
         </div>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -11,7 +11,7 @@ class Footer extends PureComponent {
           className="Footer__container-bottom-image absolute"
         />
         <div className="Footer__container pt8 flex flex-col items-center justify-center">
-          <p className="block-description color-white text-center">
+          <p className="sans-serif color-white text-center">
             by NYC based Contentful experts
           </p>
           <a 

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -4,14 +4,11 @@ import WaveSvg from 'components/WaveSvg';
 
 class Footer extends PureComponent {
   render() {
-    const { contentBlocksCount } = this.props;
-
     return (
       <div className="Footer relative w100 px1_75 md:px4 block-background flex flex-col items-center justify-center">
         <WaveSvg 
           flip={true}
           className="Footer__container-bottom-image absolute"
-          isGreyBackground={contentBlocksCount%2 === 0}
         />
         <div className="Footer__container pt8 flex flex-col items-center justify-center">
           <p className="block-description color-white text-center">

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -13,20 +13,22 @@ class Footer extends PureComponent {
           className="Footer__container-bottom-image absolute"
           isGreyBackground={contentBlocksCount%2 === 0}
         />
-        <p className="block-description color-white text-center mt4">
-          by NYC based Contentful experts
-        </p>
-        <a 
-          href="https://www.sanctuary.computer/"
-          rel="noopener noreferrer" 
-          target="_blank"
-          className="Footer__sc-logo w100"
-        >
-          <img className="w100 mt_75" 
-            src="/assets/images/sanctu-compu-logo.svg" 
-            alt="sanctuary computer logo"
-          />
-        </a>
+        <div className="Footer__container pt8 flex flex-col items-center justify-center">
+          <p className="block-description color-white text-center">
+            by NYC based Contentful experts
+          </p>
+          <a 
+            href="https://www.sanctuary.computer/"
+            rel="noopener noreferrer" 
+            target="_blank"
+            className="Footer__sc-logo w100"
+          >
+            <img className="w100 mt_75" 
+              src="/assets/images/sanctu-compu-logo.svg" 
+              alt="sanctuary computer logo"
+            />
+          </a>
+        </div>
       </div>
     )
   }

--- a/src/components/Hero/index.js
+++ b/src/components/Hero/index.js
@@ -8,7 +8,10 @@ class Hero extends PureComponent {
   render() {
     return (
       <div className="Hero relative px1_75 lg:px4 flex flex-col justify-center items-center">
-        <WaveSvg className="Hero__container-bottom-image absolute"/>
+        <WaveSvg 
+          className="Hero__container-bottom-image absolute"
+          isGreyBackground={true}
+        />
         <div className="w100 mxauto block-width w100 flex flex-col lg:flex-row items-center lg:items-start lg:justify-between">
           <div className="Hero__content lg:mt2 col-12 lg:col-6 py2 lg:pr4">
             <h2 className="block-title color-white bold text-center lg:text-left mb1_5">{this.props.title}</h2>

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -34,7 +34,7 @@ class Input extends Component {
     return (
       <div className="Input my2 flex flex-row items-center">
         <input className={cx(
-          "Input__container border-color-dark-blue px1", 
+          "Input__container border-color-blue-grey bg-color-grey-light px1", 
           {
             'Input__container--full-width': !copyIsAvailable
           })} 

--- a/src/styles/_globals.scss
+++ b/src/styles/_globals.scss
@@ -46,7 +46,7 @@ button {
 }
 
 .drop-shadow {
-  box-shadow: 0 0 2.5rem 0 rgba(102, 102, 102, 0.5);
+  box-shadow: 0 0 2.5rem 0 rgba(102, 102, 102, 0.4);
 }
 
 .block-background {

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -20,6 +20,6 @@
 .block-description {
   @extend .sans-serif;
   font-size: 1rem;
-  line-height: 1.5rem;
+  line-height: 1.65rem;
   letter-spacing: -0.4px;
 }

--- a/src/styles/components/BlockTitleDescription.scss
+++ b/src/styles/components/BlockTitleDescription.scss
@@ -1,6 +1,15 @@
 .BlockTitleDescription {
-  &:nth-of-type(odd) {
+  &:nth-of-type(even) {
     background-color: color('blue-grey-light');
+  }
+
+  
+  &:nth-of-type(2) {
+    padding-top: 16rem;
+    
+    @include media('lg-up') {
+      padding-top: 6rem;
+    }
   }
 
   &__container {

--- a/src/styles/components/BlockTitleDescription.scss
+++ b/src/styles/components/BlockTitleDescription.scss
@@ -1,6 +1,6 @@
 .BlockTitleDescription {
   &:nth-of-type(odd) {
-    background-color: color('light-blue-grey');
+    background-color: color('blue-grey-light');
   }
 
   &__container {

--- a/src/styles/components/Footer.scss
+++ b/src/styles/components/Footer.scss
@@ -10,4 +10,8 @@
     top: -2px;
     left: -20%;
   }
+
+  &__container {
+    flex-grow: 1;
+  }
 }

--- a/src/styles/components/Footer.scss
+++ b/src/styles/components/Footer.scss
@@ -1,8 +1,9 @@
 .Footer {
   height: 25rem;
+  font-size: 0.8rem;
 
   &__sc-logo {
-    max-width: 22.25rem;
+    max-width: 15rem;
   }
   
   &__container-bottom-image {

--- a/src/styles/components/Hero.scss
+++ b/src/styles/components/Hero.scss
@@ -31,7 +31,7 @@
     background: color('yellow');
 
     &:hover {
-      background: color('light-yellow');
+      background: color('yellow-light');
     }
   }
 

--- a/src/styles/components/Hero.scss
+++ b/src/styles/components/Hero.scss
@@ -1,10 +1,4 @@
 .Hero {
-  margin-bottom: 16rem;
-
-  @include media('lg-up') {
-    margin-bottom: 6rem;
-  }
-
   &__content {
     max-width: 30rem;
   }

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -2,7 +2,7 @@
   &__container {
     @extend .courier;
     font-size: 1.125rem;
-    border-radius: 0.3rem;
+    border-radius: 0.1rem;
     border-width: 1px;
     border-style: solid;
     height: 4rem;

--- a/src/styles/components/Input.scss
+++ b/src/styles/components/Input.scss
@@ -3,7 +3,8 @@
     @extend .courier;
     font-size: 1.125rem;
     border-radius: 0.3rem;
-    border-width: 2px;
+    border-width: 1px;
+    border-style: solid;
     height: 4rem;
     max-width: 60%;
 

--- a/src/styles/settings/_colors.scss
+++ b/src/styles/settings/_colors.scss
@@ -1,17 +1,13 @@
 $colors: (
   'white': #FFF,
   'off-white': #D8D8D8,
-  'light-grey': #F7F7F7,
+  'grey-light': #FAFDFF,
   'grey': #C5C9CD,
-  'light-blue-grey': #F2F8FB,
-  'blue-grey': #C5D2D7,
-  'sidewalk-grey': #8192A6,
-  'light-blue': #8A8F94,
-  'midnight-blue': #2D2E31,
-  'dark-blue': #192532,
+  'blue-grey-light': #F2F8FB,
+  'blue-grey': #DBE3E7,
   'black': #000,
   'brown': #3E2C0F,
   'green': #0EB880,
   'yellow': #FFD85F,
-  'light-yellow': #FFE492
+  'yellow-light': #FFE492
 );

--- a/src/styles/settings/_colors.scss
+++ b/src/styles/settings/_colors.scss
@@ -1,7 +1,7 @@
 $colors: (
   'white': #FFF,
   'off-white': #D8D8D8,
-  'grey-light': #FAFDFF,
+  'grey-light': #f7f9fa,
   'grey': #C5C9CD,
   'blue-grey-light': #F2F8FB,
   'blue-grey': #DBE3E7,


### PR DESCRIPTION
- Drop the opacity of that hero image drop shadow by 5%
- Increase line-height for body copy and lists to 1.65rem
- Increase top padding for block's paragraph text on the right a little so it lines up better with the title on the left
- Tone down the code input fields a bit to match their design: thinner, lighter borders with much smaller border-radius
- Vertically center the footer logo/text
- Make footer logo smaller and "By NYC-based Contentful experts" smaller